### PR TITLE
feat: update server port in application properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,6 @@
+server.port=9090
 spring.application.name=sathish-run2025-ai
+
 
 spring.ai.openai.api-key=${API_KEY}
 


### PR DESCRIPTION
Set the server port to 9090 in the application properties file. This  change allows the application to run on a different port, avoiding  conflicts with other services and improving deployment flexibility.